### PR TITLE
refactor. MariaDB, ElasticSearch, Redis 에서 각 plannerTop6 조회 성능 테스트

### DIFF
--- a/src/main/java/com/zero/triptalk/component/RedisUtil.java
+++ b/src/main/java/com/zero/triptalk/component/RedisUtil.java
@@ -1,6 +1,12 @@
 package com.zero.triptalk.component;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zero.triptalk.planner.entity.PlannerDocument;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RMapCache;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -9,6 +15,8 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Component
@@ -16,7 +24,9 @@ import java.util.concurrent.TimeUnit;
 public class RedisUtil {
 
     private final StringRedisTemplate stringRedisTemplate;
-
+    private final RedissonClient redissonClient;
+    private final ObjectMapper objectMapper;
+    private static final String MAP_CACHE_KEY = "planner";
 
     public String getData(String key) {
         ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
@@ -67,5 +77,30 @@ public class RedisUtil {
         stringRedisTemplate.expire(key, secondsUntilMidnight, TimeUnit.SECONDS);
     }
 
+    public void setPlannerTop6(String key, List<PlannerDocument> planners) {
+        RMapCache<String, String> cache = redissonClient.getMapCache(MAP_CACHE_KEY, StringCodec.INSTANCE);
 
+        try {
+            String json = objectMapper.writeValueAsString(planners);
+            cache.put(key, json, 2, TimeUnit.MINUTES);
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error serializing PlannerDocument list", e);
+        }
+    }
+
+    public List<PlannerDocument> getPlannerTop6(String key) {
+        RMapCache<String, String> cache = redissonClient.getMapCache(MAP_CACHE_KEY, StringCodec.INSTANCE);
+        String json = cache.get(key);
+
+        if (json == null) {
+            return Collections.emptyList();
+        }
+
+        try {
+            return objectMapper.readValue(json, objectMapper.getTypeFactory().constructCollectionType(List.class, PlannerDocument.class));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
+++ b/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
@@ -4,9 +4,7 @@ import com.zero.triptalk.application.PlannerApplication;
 import com.zero.triptalk.planner.dto.request.CreatePlannerInfo;
 import com.zero.triptalk.planner.dto.request.PlannerDetailRequest;
 import com.zero.triptalk.planner.dto.request.UpdatePlannerInfo;
-import com.zero.triptalk.planner.dto.response.PlannerDetailResponse;
-import com.zero.triptalk.planner.dto.response.PlannerListResult;
-import com.zero.triptalk.planner.dto.response.PlannerResponse;
+import com.zero.triptalk.planner.dto.response.*;
 import com.zero.triptalk.planner.service.PlannerDetailService;
 import com.zero.triptalk.planner.service.PlannerService;
 import com.zero.triptalk.planner.type.SortType;
@@ -108,6 +106,18 @@ public class PlannerController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    @GetMapping("/maria")
+    public ResponseEntity<List<PlannerSearchResponse>> getPlannerTop6FromMaria() {
 
+        return ResponseEntity.ok(plannerService.getPlannerTop6FromMaria());
+    }
+
+    @GetMapping("/details/distance")
+    public ResponseEntity<List<PlannerDetailSearchResponse>> getPlannerDetailsByDistance(@RequestParam double longitude, @RequestParam double latitude) {
+
+        List<PlannerDetailSearchResponse> result = plannerDetailService.getPlannerDetailsByDistance(longitude, latitude);
+
+        return ResponseEntity.ok(result);
+    }
 
 }

--- a/src/main/java/com/zero/triptalk/planner/dto/response/PlannerSearchResponse.java
+++ b/src/main/java/com/zero/triptalk/planner/dto/response/PlannerSearchResponse.java
@@ -1,5 +1,7 @@
 package com.zero.triptalk.planner.dto.response;
 
+import com.querydsl.core.Tuple;
+import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.entity.PlannerDocument;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -7,6 +9,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
+
+import static com.zero.triptalk.like.entity.QPlannerLike.plannerLike;
+import static com.zero.triptalk.planner.entity.QPlanner.planner;
+import static com.zero.triptalk.user.entity.QUserEntity.userEntity;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -44,6 +51,22 @@ public class PlannerSearchResponse {
                 .endDate(document.getEndDate())
                 .views(document.getViews())
                 .likeCount(document.getLikes())
+                .build();
+    }
+
+    public static PlannerSearchResponse ofTuple(Tuple tuple) {
+
+        Planner plannerOfTuple = Objects.requireNonNull(tuple.get(planner));
+
+        return PlannerSearchResponse.builder()
+                .plannerId(plannerOfTuple.getPlannerId())
+                .title(plannerOfTuple.getTitle())
+                .thumbnail(plannerOfTuple.getThumbnail())
+                .nickname(tuple.get(userEntity.nickname))
+                .startDate(plannerOfTuple.getStartDate())
+                .endDate(plannerOfTuple.getEndDate())
+                .views(plannerOfTuple.getViews())
+                .likeCount(tuple.get(plannerLike.likeCount))
                 .build();
     }
 }

--- a/src/main/java/com/zero/triptalk/planner/entity/PlannerDetail.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/PlannerDetail.java
@@ -28,6 +28,8 @@ public class PlannerDetail extends BaseEntity {
     private String description;
 
     @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "planner_detail_images", joinColumns = @JoinColumn(name = "planner_detail_id"))
+    @Column(name = "image")
     private List<String> images;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/zero/triptalk/planner/entity/PlannerDocument.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/PlannerDocument.java
@@ -6,10 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.elasticsearch.annotations.Document;
-import org.springframework.data.elasticsearch.annotations.Field;
-import org.springframework.data.elasticsearch.annotations.FieldType;
-import org.springframework.data.elasticsearch.annotations.WriteTypeHint;
+import org.springframework.data.elasticsearch.annotations.*;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -29,12 +26,15 @@ public class PlannerDocument {
     private String thumbnail;
     private Long userId;
     private String userNickname;
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime startDate;
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime endDate;
     @Field(type = FieldType.Integer)
     private Long views;
     @Field(type = FieldType.Integer)
     private Long likes;
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime createdAt;
 
     @Builder
@@ -67,5 +67,9 @@ public class PlannerDocument {
                 .likes(tuple.get(plannerLike.likeCount))
                 .createdAt(plannerFromTuple.getCreatedAt())
                 .build();
+    }
+
+    public Long getLikes() {
+        return likes == null ? 0 : likes;
     }
 }

--- a/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerRepository.java
+++ b/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerRepository.java
@@ -96,4 +96,17 @@ public class CustomPlannerRepository {
                 .fetch();
 
     }
+
+    public List<Tuple> getPlannerTop6ByLikes() {
+
+        return queryFactory.select(planner, userEntity.nickname, plannerLike.likeCount)
+                .from(planner)
+                .leftJoin(userEntity).on(planner.user.eq(userEntity))
+                .leftJoin(plannerLike).on(planner.eq(plannerLike.planner))
+                .orderBy(plannerLike.likeCount.desc())
+                .limit(6)
+                .fetch();
+    }
+
+
 }

--- a/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerSearchRepository.java
+++ b/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerSearchRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
 import org.springframework.data.elasticsearch.core.query.FetchSourceFilter;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,4 +40,22 @@ public class CustomPlannerSearchRepository {
                 .stream().map(SearchHit::getContent).collect(Collectors.toList());
     }
 
+
+    // ElasticsearchConfig 에서 해결안되면 해당 매서드로 불러와보기 - 차선책
+    public List<PlannerDocument> getAllByCreatedAtAndModifiedAt(LocalDateTime oneMonthAgo, Pageable pageable) {
+
+        Criteria criteria = Criteria.where("createdAt").and("modifiedAt").greaterThanEqual(oneMonthAgo);
+
+        CriteriaQuery query = CriteriaQuery.builder(criteria)
+                .withSourceFilter(new FetchSourceFilter(
+                        new String[]{"plannerId", "title",
+                                "thumbnail", "userId",
+                                "userNickname", "startDate",
+                                "endDate", "views", "likes", "createdAt"}, null))
+                .withPageable(pageable)
+                .build();
+
+        return elasticsearchOperations.search(query, PlannerDocument.class)
+                .stream().map(SearchHit::getContent).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/zero/triptalk/planner/repository/PlannerDetailRepository.java
+++ b/src/main/java/com/zero/triptalk/planner/repository/PlannerDetailRepository.java
@@ -2,6 +2,8 @@ package com.zero.triptalk.planner.repository;
 
 import com.zero.triptalk.planner.entity.PlannerDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +12,16 @@ import java.util.List;
 public interface PlannerDetailRepository extends JpaRepository<PlannerDetail, Long> {
 
     List<PlannerDetail> findByPlanner_PlannerId(Long plannerId);
+
+    @Query(value = "SELECT ST_Distance_Sphere(point(p.longitude ,p.latitude), point(:longitude, :latitude)) AS distance, " +
+            "pd.planner_detail_id AS plannerDetailId, pd.description, pd.date, u.nickname, u.profile, p.road_address, p.longitude, p.latitude, GROUP_CONCAT(pdi.image) AS images " +
+            "FROM planner_detail pd " +
+            "LEFT JOIN user u ON pd.user_id = u.user_id " +
+            "LEFT JOIN planner_detail_images pdi ON pd.planner_detail_id = pdi.planner_detail_planner_detail_id " +
+            "LEFT JOIN place p ON p.place_id = pd.place_id " +
+            "WHERE ST_Distance_Sphere(point(p.longitude ,p.latitude), point(:longitude, :latitude)) <= 3000 " +
+            "GROUP BY pd.planner_detail_id, pd.description, pd.date, u.nickname, u.profile, p.road_address, p.longitude, p.latitude " +
+            "ORDER BY distance " +
+            "LIMIT 6", nativeQuery = true)
+    List<Object[]> findTop6PlannerDetailsWithinDistance(@Param("longitude") double longitude, @Param("latitude") double latitude);
 }

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
@@ -5,6 +5,7 @@ import com.zero.triptalk.exception.custom.UserException;
 import com.zero.triptalk.image.service.ImageService;
 import com.zero.triptalk.planner.dto.response.PlannerDetailListResponse;
 import com.zero.triptalk.planner.dto.response.PlannerDetailResponse;
+import com.zero.triptalk.planner.dto.response.PlannerDetailSearchResponse;
 import com.zero.triptalk.planner.entity.PlannerDetail;
 import com.zero.triptalk.planner.repository.CustomPlannerDetailRepository;
 import com.zero.triptalk.planner.repository.PlannerDetailRepository;
@@ -15,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.NOT_FOUND_PLANNER_DETAIL;
@@ -83,5 +86,32 @@ public class PlannerDetailService {
             throw new PlannerDetailException(NOT_FOUND_PLANNER_DETAIL);
         }
         return byPlanner;
+    }
+
+    /**
+     * 범위 검색 결과 from MariaDB
+     */
+    public List<PlannerDetailSearchResponse> getPlannerDetailsByDistance(double longitude, double latitude) {
+
+        List<Object[]> results = plannerDetailRepository.findTop6PlannerDetailsWithinDistance(longitude, latitude);
+
+        List<PlannerDetailSearchResponse> plannerDetails = new ArrayList<>();
+
+        for (Object[] result : results) {
+
+            PlannerDetailSearchResponse response = PlannerDetailSearchResponse.builder()
+                    .plannerDetailId(((Number) result[1]).longValue())
+                    .description((String) result[2])
+                    .date(((Timestamp) result[3]).toLocalDateTime())
+                    .nickname((String) result[4])
+                    .profile((String) result[5])
+                    .lon((Double) result[6])
+                    .lat((Double) result[7])
+                    .build();
+
+            plannerDetails.add(response);
+        }
+
+        return plannerDetails;
     }
 }

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
@@ -1,10 +1,12 @@
 package com.zero.triptalk.planner.service;
 
+import com.querydsl.core.Tuple;
 import com.zero.triptalk.component.RedisUtil;
 import com.zero.triptalk.exception.code.PlannerErrorCode;
 import com.zero.triptalk.exception.custom.PlannerException;
 import com.zero.triptalk.planner.dto.request.PlannerRequest;
 import com.zero.triptalk.planner.dto.response.PlannerListResult;
+import com.zero.triptalk.planner.dto.response.PlannerSearchResponse;
 import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.repository.CustomPlannerRepository;
 import com.zero.triptalk.planner.repository.PlannerRepository;
@@ -24,7 +26,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -108,5 +112,16 @@ public class PlannerService {
             redisUtil.addUserSet(userKey, plannerId);
             redisUtil.increaseViews(plannerKey);
         }
+    }
+
+    /**
+     * Top6 From MariaDB
+     */
+    public List<PlannerSearchResponse> getPlannerTop6FromMaria() {
+
+        List<Tuple> plannerTop6ByLikes = customPlannerRepository.getPlannerTop6ByLikes();
+
+        return plannerTop6ByLikes.stream().map(PlannerSearchResponse::ofTuple).collect(Collectors.toList());
+
     }
 }

--- a/src/main/java/com/zero/triptalk/search/controller/SearchController.java
+++ b/src/main/java/com/zero/triptalk/search/controller/SearchController.java
@@ -25,7 +25,11 @@ public class SearchController {
     @PreAuthorize("hasAuthority('USER')")
     public ResponseEntity<List<PlannerSearchResponse>> getTop6Planners() {
 
-        return ResponseEntity.ok(searchService.getTop6PlannersWithLikes());
+        /* redis 에서 조회 */
+        return ResponseEntity.ok(searchService.getTop6Planners());
+
+        /* elasticsearch 에서 조회 */
+//        return ResponseEntity.ok(searchService.getTop6PlannersFromES());
     }
 
     @GetMapping("/search/{region}/{searchType}")

--- a/src/main/java/com/zero/triptalk/search/service/SearchService.java
+++ b/src/main/java/com/zero/triptalk/search/service/SearchService.java
@@ -1,5 +1,6 @@
 package com.zero.triptalk.search.service;
 
+import com.zero.triptalk.component.RedisUtil;
 import com.zero.triptalk.exception.code.SearchErrorCode;
 import com.zero.triptalk.exception.code.UserErrorCode;
 import com.zero.triptalk.exception.custom.SearchException;
@@ -11,18 +12,22 @@ import com.zero.triptalk.planner.entity.PlannerDocument;
 import com.zero.triptalk.planner.repository.CustomPlannerDetailSearchRepository;
 import com.zero.triptalk.planner.repository.CustomPlannerSearchRepository;
 import com.zero.triptalk.planner.repository.PlannerSearchRepository;
+import com.zero.triptalk.search.PlannerWithPopularity;
 import com.zero.triptalk.user.entity.UserDocument;
 import com.zero.triptalk.user.repository.UserSearchRepository;
 import com.zero.triptalk.user.response.UserInfoSearchResponse;
 import com.zero.triptalk.user.response.UserSearchResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.NoSuchIndexException;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,15 +39,36 @@ public class SearchService {
     private final CustomPlannerSearchRepository customPlannerSearchRepository;
     private final CustomPlannerDetailSearchRepository customPlannerDetailSearchRepository;
     private final UserSearchRepository userSearchRepository;
+    private final RedisUtil redisUtil;
 
-    public List<PlannerSearchResponse> getTop6PlannersWithLikes() throws NoSuchIndexException {
+    private static final String CACHE_KEY = "planner_top6";
 
-        List<PlannerDocument> top6ByOrderByLikeCountDesc = plannerSearchRepository
-                                                            .findTop6ByOrderByLikesDesc();
+    /**
+     * Top6 planner from redis
+     */
+    public List<PlannerSearchResponse> getTop6Planners() throws NoSuchIndexException {
 
-        return top6ByOrderByLikeCountDesc.stream().map(PlannerSearchResponse::ofDocument)
-                                                           .collect(Collectors.toList());
+        List<PlannerDocument> plannerTop6 = redisUtil.getPlannerTop6(CACHE_KEY);
+
+        if (plannerTop6 == null || plannerTop6.isEmpty()) {
+            List<PlannerDocument> plannerTop6FromES = this.fetchPlannerTop6FromES();
+            redisUtil.setPlannerTop6(CACHE_KEY, plannerTop6FromES);
+            return plannerTop6FromES.stream().map(PlannerSearchResponse::ofDocument).collect(Collectors.toList());
+        }
+
+        return plannerTop6.stream().map(PlannerSearchResponse::ofDocument).collect(Collectors.toList());
     }
+
+    /**
+     * Top6 planner from elasticsearch
+     */
+    public List<PlannerSearchResponse> getTop6PlannersFromES() {
+
+        List<PlannerDocument> plannerTop6 = plannerSearchRepository.findTop6ByOrderByLikesDesc();
+
+        return plannerTop6.stream().map(PlannerSearchResponse::ofDocument).collect(Collectors.toList());
+    }
+
 
     public List<PlannerDetailSearchResponse> searchByRegionAnySort(
                                         String region, String searchType, Pageable pageable)
@@ -100,5 +126,41 @@ public class SearchService {
         return detailDocuments.stream().map(PlannerDetailSearchResponse::ofDocument)
                                         .collect(Collectors.toList());
 
+    }
+
+    /**
+     * 최근 한달동안 업데이트된 planner 가져오기
+     */
+    public List<PlannerDocument> fetchPlannerTop6FromES() {
+
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
+        Pageable pageable = PageRequest.of(0, 50);
+        List<PlannerDocument> planners = customPlannerSearchRepository.getAllByCreatedAtAndModifiedAt(oneMonthAgo, pageable);
+
+        PriorityQueue<PlannerWithPopularity> plannerTop6Queue = new PriorityQueue<>(Comparator.comparingDouble(PlannerWithPopularity::getPopularity));
+
+        for(PlannerDocument planner : planners) {
+            double popularity = calculatePopularity(planner);
+            PlannerWithPopularity plannerWithPopularity = new PlannerWithPopularity(planner, popularity);
+
+            if (plannerTop6Queue.size() < 6) {
+                plannerTop6Queue.add(plannerWithPopularity);
+            } else if (plannerTop6Queue.peek().getPopularity() < popularity) {
+                plannerTop6Queue.poll();
+                plannerTop6Queue.add(plannerWithPopularity);
+            }
+        }
+
+        return plannerTop6Queue.stream()
+                .sorted(Comparator.comparingDouble(PlannerWithPopularity::getPopularity).reversed())
+                .map(PlannerWithPopularity::getPlanner)
+                .collect(Collectors.toList());
+    }
+
+    private double calculatePopularity(PlannerDocument planner) {
+
+        long hoursSinceCreated = ChronoUnit.HOURS.between(planner.getCreatedAt(), LocalDateTime.now());
+        double score = planner.getViews() + (planner.getLikes() * 2); // 조회수와 좋아요 수에 가중치 부여
+        return score / Math.pow((hoursSinceCreated + 2), 1.8); // Hacker News 알고리즘 기반의 가중치 적용
     }
 }


### PR DESCRIPTION
## TEST
### 메인화면에서 Top6 여행지를 조회하는 API를 각각 MariaDB, ElasticSearch, Redis 에서 가져와 성능 테스트 진행
- SearchController : GET /api/main 에서 ElasticSearch 와 Redis(캐싱) 에서 조회하는 메서드 생성
   ```
    public List<PlannerSearchResponse> getTop6Planners() {

        List<PlannerDocument> plannerTop6 = redisUtil.getPlannerTop6(CACHE_KEY);

        if (plannerTop6 == null || plannerTop6.isEmpty()) {
            List<PlannerDocument> plannerTop6FromES = this.fetchPlannerTop6FromES();
            redisUtil.setPlannerTop6(CACHE_KEY, plannerTop6FromES);
            return plannerTop6FromES.stream().map(PlannerSearchResponse::ofDocument).collect(Collectors.toList());
        }

        return plannerTop6.stream().map(PlannerSearchResponse::ofDocument).collect(Collectors.toList());
    }

    public List<PlannerSearchResponse> getTop6PlannersFromES() {

        List<PlannerDocument> plannerTop6 = plannerSearchRepository.findTop6ByOrderByLikesDesc();

        return plannerTop6.stream().map(PlannerSearchResponse::ofDocument).collect(Collectors.toList());
    }
- PlannerController : Get /api/plans/maria 에서 MariaDB 에서 조회하는 메서드 생성 
   ```
    public List<Tuple> getPlannerTop6ByLikes() {

        return queryFactory.select(planner, userEntity.nickname, plannerLike.likeCount)
                .from(planner)
                .leftJoin(userEntity).on(planner.user.eq(userEntity))
                .leftJoin(plannerLike).on(planner.eq(plannerLike.planner))
                .orderBy(plannerLike.likeCount.desc())
                .limit(6)
                .fetch();
    }
- RedisUtil : RMapCache 클래스를 사용하여 레디스에 String으로 저장(TTL 설정) 및 조회

   ```
        public void setPlannerTop6(String key, List<PlannerDocument> planners) {
            RMapCache<String, String> cache = redissonClient.getMapCache(MAP_CACHE_KEY, StringCodec.INSTANCE);

            try {
                String json = objectMapper.writeValueAsString(planners);
                cache.put(key, json, 2, TimeUnit.MINUTES);
    
            } catch (JsonProcessingException e) {
                throw new RuntimeException("Error serializing PlannerDocument list", e);
            }
    }

## Result

  | MariaDB | ElasticSearch | Redis
-- | -- | -- | --
평균 TPS | 8 | 99.7 `약 12배 증가` | 136.1 `약 17배 증가`
Peek TPS | 14 | 118.5 | 174.0
Executed Tests | 451 | 5601 `약 12배 증가` | 7640 `약 16배 증가`


<!-- notionvc: 8800f0e2-1fe7-4bad-bc6b-fb6f1b7d7491 -->
- MariaDB 
![mariadb](https://github.com/Krystal-13/triptalk-backend/assets/129822965/e3838eeb-5a22-4dc9-a975-8295d204809f)
- ElasticSearch
![elasticsearch](https://github.com/Krystal-13/triptalk-backend/assets/129822965/a24ba2bc-b4d3-4dff-bcf8-61e7d71b19bc)
- Redis
![redis](https://github.com/Krystal-13/triptalk-backend/assets/129822965/f0751d02-08cf-4835-88ee-60976942790b)
