### PR TITLE
refactor. ElasticSearchConfig.java

### DIFF
--- a/src/main/java/com/zero/triptalk/config/ElasticSearchConfig.java
+++ b/src/main/java/com/zero/triptalk/config/ElasticSearchConfig.java
@@ -1,12 +1,29 @@
 package com.zero.triptalk.config;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHost;
+import org.apache.http.message.BasicHeader;
+import org.elasticsearch.client.RestClient;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.elasticsearch.client.ClientConfiguration;
-import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 
+import java.util.Base64;
+
+@Slf4j
 @Configuration
-public class ElasticSearchConfig extends ElasticsearchConfiguration {
+public class ElasticSearchConfig {
+
+    private static final String BASIC = "Basic ";
+    private static final String AUTH = "Authorization";
 
     @Value("${spring.elasticsearch.hostname}")
     private String hostname;
@@ -17,10 +34,33 @@ public class ElasticSearchConfig extends ElasticsearchConfiguration {
     @Value("${spring.elasticsearch.password}")
     private String password;
 
-    @Override
-    public ClientConfiguration clientConfiguration() {
-        return ClientConfiguration.builder().connectedTo(hostname + ":" + port)
-                .withBasicAuth(userName, password)
+    @Bean
+    public RestClient restClient() {
+
+        return RestClient.builder(new HttpHost(hostname, port))
+                .setDefaultHeaders(new BasicHeader[]{
+                        new BasicHeader(AUTH,
+                                BASIC + Base64.getEncoder()
+                                        .encodeToString((userName + password).getBytes()))})
                 .build();
     }
+
+    @Bean
+    public ElasticsearchClient elasticsearchClient() {
+
+        JacksonJsonpMapper jsonpMapper = new JacksonJsonpMapper();
+        jsonpMapper.objectMapper().registerModule(new JavaTimeModule())
+                                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        ElasticsearchTransport transport = new RestClientTransport(this.restClient(), jsonpMapper);
+
+        return new ElasticsearchClient(transport);
+    }
+
+    @Bean
+    public ElasticsearchTemplate elasticsearchTemplate(ElasticsearchClient elasticsearchClient, ElasticsearchConverter elasticsearchConverter) {
+
+        return new ElasticsearchTemplate(elasticsearchClient, elasticsearchConverter);
+    }
+
 }

--- a/src/main/java/com/zero/triptalk/planner/dto/PlannerWithPopularity.java
+++ b/src/main/java/com/zero/triptalk/planner/dto/PlannerWithPopularity.java
@@ -1,0 +1,15 @@
+package com.zero.triptalk.planner.dto;
+
+import com.zero.triptalk.planner.entity.PlannerDocument;
+import lombok.Getter;
+
+@Getter
+public class PlannerWithPopularity {
+    private PlannerDocument planner;
+    private double popularity;
+
+    public PlannerWithPopularity(PlannerDocument planner, double popularity) {
+        this.planner = planner;
+        this.popularity = popularity;
+    }
+}

--- a/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerSearchRepository.java
+++ b/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerSearchRepository.java
@@ -2,7 +2,6 @@ package com.zero.triptalk.planner.repository;
 
 import com.zero.triptalk.planner.entity.PlannerDocument;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
@@ -18,7 +17,6 @@ import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
-@Slf4j
 public class CustomPlannerSearchRepository {
 
     private final ElasticsearchOperations elasticsearchOperations;
@@ -40,8 +38,6 @@ public class CustomPlannerSearchRepository {
                 .stream().map(SearchHit::getContent).collect(Collectors.toList());
     }
 
-
-    // ElasticsearchConfig 에서 해결안되면 해당 매서드로 불러와보기 - 차선책
     public List<PlannerDocument> getAllByCreatedAtAndModifiedAt(LocalDateTime oneMonthAgo, Pageable pageable) {
 
         Criteria criteria = Criteria.where("createdAt").and("modifiedAt").greaterThanEqual(oneMonthAgo);

--- a/src/main/java/com/zero/triptalk/search/service/SearchService.java
+++ b/src/main/java/com/zero/triptalk/search/service/SearchService.java
@@ -12,7 +12,7 @@ import com.zero.triptalk.planner.entity.PlannerDocument;
 import com.zero.triptalk.planner.repository.CustomPlannerDetailSearchRepository;
 import com.zero.triptalk.planner.repository.CustomPlannerSearchRepository;
 import com.zero.triptalk.planner.repository.PlannerSearchRepository;
-import com.zero.triptalk.search.PlannerWithPopularity;
+import com.zero.triptalk.planner.dto.PlannerWithPopularity;
 import com.zero.triptalk.user.entity.UserDocument;
 import com.zero.triptalk.user.repository.UserSearchRepository;
 import com.zero.triptalk.user.response.UserInfoSearchResponse;


### PR DESCRIPTION
## As Is
- Spring Data Elasticsearch의 `ElasticsearchConfiguration` 를 상속받아 구현하는 방식으로 기본설정을 따름
```
@Override
public ClientConfiguration clientConfiguration() {
    return ClientConfiguration.builder().connectedTo(hostname + ":" + port)
            .withBasicAuth(userName, password)
            .build();
```

## To Be
- Elasticsearch client 라이브러리를 직접사용하여 커스텀하게 설정
- Java 8 date/time 을 핸들링하기 위한 `JacksonJsonpMapper`에 `JavaTimeModule` 등록
- `ElasticsearchOperations` 을 사용하기 위한 `ElasticsearchTemplate` 빈 등록
```
    @Bean
    public RestClient restClient() {

        return RestClient.builder(new HttpHost(hostname, port))
                .setDefaultHeaders(new BasicHeader[]{
                        new BasicHeader(AUTH,
                                BASIC + Base64.getEncoder()
                                        .encodeToString((userName + password).getBytes()))})
                .build();
    }

    @Bean
    public ElasticsearchClient elasticsearchClient() {

        JacksonJsonpMapper jsonpMapper = new JacksonJsonpMapper();
        jsonpMapper.objectMapper().registerModule(new JavaTimeModule())
                                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

        ElasticsearchTransport transport = new RestClientTransport(this.restClient(), jsonpMapper);

        return new ElasticsearchClient(transport);
    }

    @Bean
    public ElasticsearchTemplate elasticsearchTemplate(ElasticsearchClient elasticsearchClient, ElasticsearchConverter elasticsearchConverter) {

        return new ElasticsearchTemplate(elasticsearchClient, elasticsearchConverter);
    }

```

